### PR TITLE
Reindex von Tabellenspalten funktioniert nicht

### DIFF
--- a/plugins/reindex/functions/function.reindex.inc.php
+++ b/plugins/reindex/functions/function.reindex.inc.php
@@ -1,6 +1,8 @@
 <?php
 function a587_rexsearch_reindex($_params)
 {
+  global $REX;
+  
   $columns = array();
   $id = 0;
 


### PR DESCRIPTION
weil $REX nicht gesetzt ist.
